### PR TITLE
Add missing TFTP_SERVER option

### DIFF
--- a/dhcp/packet.py
+++ b/dhcp/packet.py
@@ -87,6 +87,7 @@ class PacketOption(enum.IntEnum):
     MAX_MESSAGE_SIZE = 57
     CLASS_IDENT = 60
     CLIENT_IDENT = 61
+    TFTP_SERVER = 66
     STATIC_ROUTES = 121
     WPAD_URL = 252
 
@@ -225,7 +226,10 @@ class Option(object):
             self.value = ipaddress.ip_address(value)
             return
 
-        if self.id in (PacketOption.HOST_NAME, PacketOption.DOMAIN_NAME, PacketOption.WPAD_URL):
+        if self.id in (
+            PacketOption.HOST_NAME, PacketOption.DOMAIN_NAME, PacketOption.TFTP_SERVER,
+            PacketOption.WPAD_URL
+        ):
             self.value = value.decode('ascii')
             return
 
@@ -278,7 +282,10 @@ class Option(object):
         ):
             return b''.join(i.packed for i in self.value)
 
-        if self.id in (PacketOption.HOST_NAME, PacketOption.DOMAIN_NAME, PacketOption.WPAD_URL):
+        if self.id in (
+            PacketOption.HOST_NAME, PacketOption.DOMAIN_NAME, PacketOption.TFTP_SERVER,
+            PacketOption.WPAD_URL
+        ):
             return self.value.encode('ascii')
 
         if self.id == PacketOption.ERROR_MESSAGE:


### PR DESCRIPTION
Add support for TFTP_SERVER (option 66) to prevent the "Unknown DHCP option 66, skipped" messages in the log.

I put this file in place and rebooted, no more noise in the logs.

[Bug 22688](https://bugs.freenas.org/issues/22688)

Thanks.

Jeff
